### PR TITLE
Fix task-user binding, points system, and login button on task pages

### DIFF
--- a/HTML/tasks-photohunt.html
+++ b/HTML/tasks-photohunt.html
@@ -694,6 +694,8 @@
       });
     </script>
 
+    <script src="../JS/config.js"></script>
+    <script src="../JS/auth-check.js"></script>
     <script src="../JS/session.js" defer></script>
     <script src="../JS/progress.js" defer></script>
     <script src="../JS/task-progress.js" defer></script>

--- a/HTML/tasks-quiz.html
+++ b/HTML/tasks-quiz.html
@@ -1146,6 +1146,8 @@
       }
     </script>
 
+    <script src="/JS/config.js"></script>
+    <script src="/JS/auth-check.js"></script>
     <script src="/JS/session.js" defer></script>
     <script src="/JS/progress.js" defer></script>
     <script src="/JS/task-progress.js" defer></script>

--- a/HTML/tasks-stories.html
+++ b/HTML/tasks-stories.html
@@ -321,6 +321,8 @@
     <footer>
       Вернуться к <a href="./tasks.html">выбору типа заданий</a> или на <a href="../index.html">главную страницу</a>.
     </footer>
+    <script src="../JS/config.js"></script>
+    <script src="../JS/auth-check.js"></script>
     <script src="../JS/session.js" defer></script>
     <script src="../JS/progress.js" defer></script>
     <script src="../JS/task-progress.js" defer></script>

--- a/JS/progress.js
+++ b/JS/progress.js
@@ -1,6 +1,4 @@
 (() => {
-  const STORAGE_KEY = 'tomsk4everyone_users';
-  const SESSION_KEY = 'tomsk4everyone_session';
   const EVENT_NAME = 'profilestore:update';
 
   const TASK_DEFINITIONS = {
@@ -24,295 +22,74 @@
     },
   };
 
-  const safeJsonParse = (value, fallback) => {
-    try {
-      return JSON.parse(value ?? '');
-    } catch (error) {
-      console.error('Не удалось разобрать сохранённые данные профиля:', error);
-      return fallback;
-    }
+  const notify = (user) => {
+    document.dispatchEvent(new CustomEvent(EVENT_NAME, { detail: { user } }));
   };
 
-  const readUsers = () => safeJsonParse(localStorage.getItem(STORAGE_KEY), []);
-  const writeUsers = (users) => localStorage.setItem(STORAGE_KEY, JSON.stringify(users));
-
-  const readSession = () => safeJsonParse(localStorage.getItem(SESSION_KEY), null);
-  const writeSession = (session) => localStorage.setItem(SESSION_KEY, JSON.stringify(session));
-  const clearSession = () => localStorage.removeItem(SESSION_KEY);
-
-  const normalizeRole = (role) => (['user', 'curator', 'admin'].includes(role) ? role : 'user');
-
-  const normalizeArticles = (articles) => {
-    if (!Array.isArray(articles)) {
-      return [];
-    }
-
-    const seenIds = new Set();
-    const normalized = articles
-      .map((article, index) => {
-        if (!article) {
-          return null;
-        }
-
-        if (typeof article === 'string') {
-          const title = article.trim();
-          if (!title) {
-            return null;
-          }
-          return {
-            id: `article-${index}`,
-            title,
-            link: '',
-            createdAt: new Date().toISOString(),
-          };
-        }
-
-        if (typeof article === 'object') {
-          const title = typeof article.title === 'string' ? article.title.trim() : '';
-          if (!title) {
-            return null;
-          }
-
-          return {
-            id: typeof article.id === 'string' && article.id.trim() ? article.id : `article-${index}`,
-            title,
-            link: typeof article.link === 'string' ? article.link : '',
-            createdAt:
-              typeof article.createdAt === 'string' && article.createdAt
-                ? article.createdAt
-                : new Date().toISOString(),
-          };
-        }
-
-        return null;
-      })
-      .filter(Boolean);
-
-    return normalized.map((article, index) => {
-      let id = article.id;
-      while (seenIds.has(id)) {
-        id = `${article.id}-${seenIds.size + index + 1}`;
-      }
-      seenIds.add(id);
-      return { ...article, id };
-    });
-  };
-
-  const applyUserDefaults = (user) => {
-    const normalized = { ...user };
-    normalized.role = normalizeRole(normalized.role);
-    normalized.avatar = typeof normalized.avatar === 'string' ? normalized.avatar : '';
-    if (!Array.isArray(normalized.completedTasks)) {
-      normalized.completedTasks = [];
-    }
-    normalized.completedTasks = Array.from(
-      new Set(normalized.completedTasks.filter((taskId) => typeof taskId === 'string')),
-    );
-    normalized.articles = normalizeArticles(normalized.articles);
-    return normalized;
-  };
-
-  const toSessionUser = (user) => {
-    const normalized = applyUserDefaults(user);
-    return {
-      name: normalized.name || normalized.email,
-      email: normalized.email,
-      role: normalized.role,
-      avatar: normalized.avatar,
-      completedTasks: normalized.completedTasks,
-      articles: normalized.articles,
-    };
-  };
-
-  let currentUser = null;
-
-  const notify = () => {
-    document.dispatchEvent(
-      new CustomEvent(EVENT_NAME, {
-        detail: { user: currentUser },
-      }),
-    );
-  };
-
-  const syncSession = () => {
-    const session = readSession();
-    if (!session || !session.email) {
-      currentUser = null;
-      return null;
-    }
-
-    const users = readUsers();
-    const index = users.findIndex((item) => item.email === session.email);
-    if (index === -1) {
-      clearSession();
-      currentUser = null;
-      return null;
-    }
-
-    const storedUser = applyUserDefaults(users[index]);
-    users[index] = storedUser;
-    writeUsers(users);
-
-    currentUser = toSessionUser(storedUser);
-    writeSession(currentUser);
-    return currentUser;
-  };
-
-  const ensureUser = () => currentUser ?? syncSession();
-
-  const updateUser = (mutator) => {
-    const sessionUser = ensureUser();
-    if (!sessionUser || !sessionUser.email) {
-      return null;
-    }
-
-    const users = readUsers();
-    const index = users.findIndex((item) => item.email === sessionUser.email);
-    if (index === -1) {
-      clearSession();
-      currentUser = null;
-      notify();
-      return null;
-    }
-
-    const updated = applyUserDefaults(users[index]);
-    const draft = { ...updated };
-    if (typeof mutator === 'function') {
-      mutator(draft);
-    }
-
-    const finalUser = applyUserDefaults(draft);
-    users[index] = finalUser;
-    writeUsers(users);
-
-    currentUser = toSessionUser(finalUser);
-    writeSession(currentUser);
-    notify();
-    return currentUser;
-  };
-
-  const markTaskCompleted = (taskId) => {
-    if (!TASK_DEFINITIONS[taskId]) {
-      return false;
-    }
-
-    let added = false;
-    const result = updateUser((user) => {
-      user.completedTasks = Array.isArray(user.completedTasks) ? [...user.completedTasks] : [];
-      if (!user.completedTasks.includes(taskId)) {
-        user.completedTasks.push(taskId);
-        added = true;
-      }
-    });
-
-    return Boolean(result) && added;
-  };
-
-  const updateName = (name) => {
-    const trimmed = typeof name === 'string' ? name.trim() : '';
-    if (!trimmed) {
-      throw new Error('Имя не может быть пустым.');
-    }
-    if (trimmed.length < 2) {
-      throw new Error('Имя должно содержать не менее двух символов.');
-    }
-
-    return updateUser((user) => {
-      user.name = trimmed;
-    });
-  };
-
-  const updateAvatar = (dataUrl) => {
-    if (typeof dataUrl !== 'string' || !dataUrl.trim()) {
-      throw new Error('Не удалось загрузить изображение.');
-    }
-
-    return updateUser((user) => {
-      user.avatar = dataUrl;
-    });
-  };
-
-  const addArticle = ({ title, link }) => {
-    const trimmedTitle = typeof title === 'string' ? title.trim() : '';
-    if (!trimmedTitle) {
-      throw new Error('Введите название статьи.');
-    }
-
-    const sanitizedLink = typeof link === 'string' ? link.trim() : '';
-    const id = `article-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
-
-    const result = updateUser((user) => {
-      const articles = Array.isArray(user.articles) ? [...user.articles] : [];
-      articles.push({
-        id,
-        title: trimmedTitle,
-        link: sanitizedLink,
-        createdAt: new Date().toISOString(),
-      });
-      user.articles = articles;
-    });
-
-    if (!result) {
-      return null;
-    }
-
-    return result.articles.find((article) => article.id === id) ?? null;
-  };
-
-  const removeArticle = (articleId) => {
-    if (typeof articleId !== 'string') {
-      return null;
-    }
-
-    return updateUser((user) => {
-      if (!Array.isArray(user.articles)) {
-        user.articles = [];
-        return;
-      }
-      user.articles = user.articles.filter((article) => article.id !== articleId);
-    });
+  const getCurrentUser = () => {
+    if (!window.authHelper) return null;
+    return window.authHelper.getUser();
   };
 
   const isTaskCompleted = (taskId) => {
-    const user = ensureUser();
-    if (!user) {
-      return false;
-    }
+    const user = getCurrentUser();
+    if (!user) return false;
     return Array.isArray(user.completedTasks) && user.completedTasks.includes(taskId);
   };
 
-  const logout = () => {
-    clearSession();
-    currentUser = null;
-    notify();
+  const markTaskCompleted = async (taskId) => {
+    if (!TASK_DEFINITIONS[taskId]) return false;
+    if (isTaskCompleted(taskId)) return false;
+    if (!window.authHelper || !window.authHelper.isLoggedIn()) return false;
+
+    const token = window.authHelper.getToken();
+    const API_BASE = window.APP_CONFIG?.API_BASE || '';
+
+    try {
+      const res = await fetch(`${API_BASE}/tasks/complete`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ taskId }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Ошибка сервера');
+
+      // Update user_data in localStorage so all other components see the change
+      const currentUser = getCurrentUser();
+      if (currentUser) {
+        const updated = {
+          ...currentUser,
+          completedTasks: data.completedTasks || currentUser.completedTasks,
+          balance: data.balance ?? currentUser.balance,
+        };
+        localStorage.setItem('user_data', JSON.stringify(updated));
+      }
+
+      notify(getCurrentUser());
+      return true;
+    } catch (err) {
+      console.error('Ошибка при отметке задания:', err);
+      return false;
+    }
   };
 
   const onChange = (callback) => {
-    if (typeof callback !== 'function') {
-      return () => {};
-    }
-    const handler = (event) => {
-      callback(event.detail?.user ?? null);
-    };
+    if (typeof callback !== 'function') return () => {};
+    const handler = (event) => callback(event.detail?.user ?? null);
     document.addEventListener(EVENT_NAME, handler);
-    return () => {
-      document.removeEventListener(EVENT_NAME, handler);
-    };
+    return () => document.removeEventListener(EVENT_NAME, handler);
   };
 
-  syncSession();
-
   window.ProfileStore = {
-    getCurrentUser: () => ensureUser(),
+    getCurrentUser,
     getTaskDefinitions: () => ({ ...TASK_DEFINITIONS }),
     isTaskCompleted,
     markTaskCompleted,
-    updateName,
-    updateAvatar,
-    addArticle,
-    removeArticle,
-    logout,
     onChange,
-    sync: () => syncSession(),
+    sync: () => notify(getCurrentUser()),
   };
 })();

--- a/JS/task-progress.js
+++ b/JS/task-progress.js
@@ -1,42 +1,34 @@
 (() => {
   const store = window.ProfileStore;
-  if (!store) {
-    return;
-  }
+  if (!store) return;
 
   const blocks = Array.from(document.querySelectorAll('[data-task-progress]'));
-  if (!blocks.length) {
-    return;
-  }
+  if (!blocks.length) return;
 
   const defaultMessages = {
-    login: 'Войдите в личный кабинет, чтобы отслеживать выполнение задания.',
-    manual: 'После выполнения отметьте задание, чтобы оно появилось в профиле.',
-    auto: 'Пройдите задание, и результат автоматически появится в профиле.',
-    completed: 'Отлично! Задание отмечено как выполненное.',
+    login:     'Войдите в личный кабинет, чтобы отслеживать выполнение задания.',
+    manual:    'После выполнения отметьте задание, чтобы оно появилось в профиле.',
+    auto:      'Пройдите задание, и результат автоматически появится в профиле.',
+    completed: 'Отлично! Задание выполнено, баллы начислены.',
   };
 
   const updateBlock = (block, user) => {
     const taskId = block.dataset.taskProgress;
-    if (!taskId) {
-      return;
-    }
+    if (!taskId) return;
 
     const status = block.querySelector('[data-task-status]');
     const button = block.querySelector('[data-task-complete]');
     const isCompleted = user ? store.isTaskCompleted(taskId) : false;
-    const isManual = Boolean(button);
 
     block.classList.toggle('is-completed', Boolean(user) && isCompleted);
 
-    if (!status) {
-      return;
-    }
+    if (!status) return;
 
     if (!user) {
       if (button) {
         button.disabled = true;
         button.setAttribute('aria-disabled', 'true');
+        button.textContent = 'Отметить выполненным';
       }
       status.textContent = defaultMessages.login;
       return;
@@ -45,16 +37,14 @@
     if (button) {
       button.disabled = isCompleted;
       button.setAttribute('aria-disabled', isCompleted ? 'true' : 'false');
-      button.textContent = isCompleted ? 'Задание выполнено' : 'Отметить выполненным';
+      button.textContent = isCompleted ? 'Задание выполнено ✓' : 'Отметить выполненным';
     }
 
-    if (isCompleted) {
-      status.textContent = defaultMessages.completed;
-    } else if (isManual) {
-      status.textContent = defaultMessages.manual;
-    } else {
-      status.textContent = defaultMessages.auto;
-    }
+    status.textContent = isCompleted
+      ? defaultMessages.completed
+      : button
+        ? defaultMessages.manual
+        : defaultMessages.auto;
   };
 
   const render = () => {
@@ -64,23 +54,27 @@
 
   blocks.forEach((block) => {
     const button = block.querySelector('[data-task-complete]');
-    if (!button) {
-      return;
-    }
+    if (!button) return;
 
-    button.addEventListener('click', () => {
+    button.addEventListener('click', async () => {
       const taskId = block.dataset.taskProgress;
-      if (!taskId) {
-        return;
-      }
+      if (!taskId) return;
 
-      const success = store.markTaskCompleted(taskId);
+      button.disabled = true;
+      button.textContent = 'Сохранение...';
+
+      const success = await store.markTaskCompleted(taskId);
+
       if (!success) {
         block.classList.add('task-progress--error');
-        setTimeout(() => {
-          block.classList.remove('task-progress--error');
-        }, 400);
+        setTimeout(() => block.classList.remove('task-progress--error'), 400);
+        // Re-enable if not actually completed
+        if (!store.isTaskCompleted(taskId)) {
+          button.disabled = false;
+          button.textContent = 'Отметить выполненным';
+        }
       }
+
       render();
     });
   });

--- a/backend/app.py
+++ b/backend/app.py
@@ -52,6 +52,12 @@ MODERATOR_STATUSES = {'needs_revision', 'approved', 'published'}
 
 TEMPLATE_TYPES = {'classic', 'photoreport', 'route'}
 
+TASK_DEFINITIONS = {
+    'quiz-legends':      {'title': 'Тест «Легенды Томска»',         'points': 25},
+    'photohunt-chekhov': {'title': 'Фотоохота: найди улицу Чехова', 'points': 40},
+    'stories-open':      {'title': 'Истории жителей',               'points': 35},
+}
+
 
 def get_db_connection():
     return psycopg2.connect(**DB_CONFIG)
@@ -101,6 +107,7 @@ def normalize_user_data(user_data):
         'email': user_data['email'],
         'role': ROLE_UI.get(user_data['role'], 'user'),
         'avatar': user_data.get('avatar_url') or '/Sourse/Icons/userIco.png',
+        'balance': user_data.get('balance') or 0,
         'completedTasks': [],
         'articles': [],
     }
@@ -211,12 +218,19 @@ def login():
             'createdAt': row['created_at'].isoformat(),
         } for row in cur.fetchall()]
 
-        cur.execute('SELECT task_id FROM user_tasks WHERE user_id = %s', (user_data['id'],))
-        completed_tasks = [str(row['task_id']) for row in cur.fetchall()]
+        cur.execute(
+            'SELECT task_slug FROM user_task_completions WHERE user_id = %s',
+            (user_data['id'],),
+        )
+        completed_tasks = [row['task_slug'] for row in cur.fetchall()]
+
+        cur.execute('SELECT balance FROM users WHERE id = %s', (user_data['id'],))
+        balance_row = cur.fetchone()
 
         user = normalize_user_data(user_data)
         user['articles'] = articles
         user['completedTasks'] = completed_tasks
+        user['balance'] = balance_row['balance'] if balance_row else 0
         token = create_jwt_token(user_data['id'])
         return jsonify({'message': 'Вход выполнен успешно!', 'user': user, 'token': token})
     finally:
@@ -262,6 +276,58 @@ def update_profile(current_user_id):
             return jsonify({'error': 'Пользователь не найден'}), 404
         conn.commit()
         return jsonify({'message': 'Профиль обновлен', 'user': normalize_user_data(row)})
+    finally:
+        cur.close()
+        conn.close()
+
+
+# ─── Task completion ──────────────────────────────────────────────────────────
+
+@app.route('/api/tasks/complete', methods=['POST'])
+@token_required
+def complete_task(current_user_id):
+    data = request.get_json(silent=True) or {}
+    task_slug = (data.get('taskId') or '').strip()
+
+    if not task_slug or task_slug not in TASK_DEFINITIONS:
+        return jsonify({'error': 'Неизвестное задание'}), 400
+
+    task_points = TASK_DEFINITIONS[task_slug]['points']
+
+    conn = get_db_connection()
+    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+    try:
+        cur.execute(
+            '''INSERT INTO user_task_completions (user_id, task_slug, points_awarded)
+               VALUES (%s, %s, %s)
+               ON CONFLICT (user_id, task_slug) DO NOTHING
+               RETURNING id''',
+            (current_user_id, task_slug, task_points),
+        )
+        inserted = cur.fetchone()
+        if not inserted:
+            return jsonify({'error': 'Задание уже выполнено'}), 409
+
+        cur.execute(
+            'UPDATE users SET balance = COALESCE(balance, 0) + %s WHERE id = %s RETURNING balance',
+            (task_points, current_user_id),
+        )
+        balance_row = cur.fetchone()
+        new_balance = balance_row['balance'] if balance_row else 0
+        conn.commit()
+
+        cur.execute(
+            'SELECT task_slug FROM user_task_completions WHERE user_id = %s',
+            (current_user_id,),
+        )
+        completed_tasks = [row['task_slug'] for row in cur.fetchall()]
+
+        return jsonify({
+            'message': f'Задание выполнено! Начислено {task_points} кедрокоинов.',
+            'completedTasks': completed_tasks,
+            'balance': new_balance,
+            'pointsAwarded': task_points,
+        })
     finally:
         cur.close()
         conn.close()

--- a/tomsk-db/init/003_task_completions.sql
+++ b/tomsk-db/init/003_task_completions.sql
@@ -1,0 +1,11 @@
+-- Migration: user_task_completions
+-- Stores task completions by string slug so frontend IDs match DB records
+
+CREATE TABLE IF NOT EXISTS user_task_completions (
+    id            SERIAL PRIMARY KEY,
+    user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    task_slug     TEXT    NOT NULL,
+    points_awarded INTEGER NOT NULL DEFAULT 0,
+    completed_at  TIMESTAMPTZ DEFAULT now(),
+    UNIQUE (user_id, task_slug)
+);


### PR DESCRIPTION
Task 1 – tasks/points:
- Add user_task_completions table (user_id, task_slug, UNIQUE) so each task can only be completed once per user
- Add POST /api/tasks/complete endpoint: records completion, awards points to users.balance, returns updated completedTasks + balance
- Update login to load completedTasks from user_task_completions and include balance in the response
- Rewrite progress.js to read auth state from localStorage.user_data (JWT system) instead of the old tomsk4everyone_session store; calls backend on completion and updates localStorage so all components stay in sync

Task 2 – login button bug:
- task pages loaded session.js (which requires window.authHelper) but never loaded auth-check.js, so authHelper was undefined and the login/profile button was never updated
- Add config.js + auth-check.js (without defer) before session.js on tasks-quiz.html, tasks-photohunt.html, tasks-stories.html

https://claude.ai/code/session_01Q6PPj4dM7QCK8rgPdddgr3